### PR TITLE
KIT-38 - We need a python based pulumi svmkit example for a network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 *\#*
 Pulumi.*.yaml
+__pycache__
+venv

--- a/aws-network-spe-py/Pulumi.yaml
+++ b/aws-network-spe-py/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: aws-network-spe-py
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv
+    typechecker: pyright
+description: A Python example of a multi-node Solana Permissioned Environment in AWS

--- a/aws-network-spe-py/README.md
+++ b/aws-network-spe-py/README.md
@@ -1,0 +1,108 @@
+# Solana Permissioned Environment Inside an AWS VPC
+
+This example brings up a cluster of Solana validators, all using private addresses, inside an AWS VPC.
+Genesis is performed, a snapshot is distributed, and gossip is set up on private addresses inside the VPC.
+
+## Running the Example
+
+0. Have `pulumi` installed, logged in to wherever you're storing state, and configured to work with AWS.
+
+- https://www.pulumi.com/docs/iac/cli/commands/pulumi_login/
+- https://github.com/pulumi/pulumi-aws?tab=readme-ov-file#configuration
+
+1. Run `pulumi install`; this will install all of the required pieces for this example.
+
+```
+% pulumi install
+Installing dependencies...
+
+Creating virtual environment...
+Finished creating virtual environment
+Updating pip, setuptools, and wheel in virtual environment...
+Requirement already satisfied: pip in ./venv/lib/python3.13/site-packages (24.2)
+
+.
+.
+.
+
+Finished installing dependencies
+```
+
+2. Run `pulumi up`
+
+```
+% pulumi up
+Please choose a stack, or create a new one: <create a new stack>
+Please enter your desired stack name.
+To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`): dev
+Created stack 'dev'
+Previewing update (dev)
+
+View in Browser (Ctrl+O): https://app.pulumi.com/mylog/dev/previews/390sd21119-5cd0-497d-a945-d86738a9
+
+     Type                       Name                             Plan       Info
+ +   pulumi:pulumi:Stack        aws-network-spe-py-dev           create     1 message
+ +   ├─ aws:ec2:SecurityGroup   external-access                  create
+ +   ├─ aws:ec2:SecurityGroup   internal-access                  create
+ +   ├─ tls:index:PrivateKey    bootstrap-node-ssh-key           create
+ +   ├─ svmkit:index:KeyPair    bootstrap-node-vote-account-key  create
+ +   ├─ svmkit:index:KeyPair    bootstrap-node-validator-key     create
+ +   ├─ svmkit:index:KeyPair    stake-account-key                create
+ +   ├─ aws:ec2:KeyPair         bootstrap-node-keypair           create
+ +   ├─ svmkit:index:KeyPair    faucet-key                       create
+ +   ├─ svmkit:index:KeyPair    treasury-key                     create
+ +   ├─ svmkit:index:KeyPair    node1-validator-key              create
+ +   ├─ aws:ec2:Instance        node1-instance                   create
+ +   ├─ svmkit:index:KeyPair    node0-validator-key              create
+ +   ├─ svmkit:index:KeyPair    node1-vote-account-key           create
+ +   ├─ svmkit:index:KeyPair    node0-vote-account-key           create
+ +   ├─ tls:index:PrivateKey    node1-ssh-key                    create
+ +   ├─ aws:ec2:KeyPair         node1-keypair                    create
+ +   ├─ aws:ec2:Instance        node0-instance                   create
+ +   ├─ tls:index:PrivateKey    node0-ssh-key                    create
+ +   ├─ aws:ec2:KeyPair         node0-keypair                    create
+ +   ├─ aws:ec2:Instance        bootstrap-node-instance          create
+ +   ├─ svmkit:genesis:Solana   genesis                          create
+ +   ├─ svmkit:validator:Agave  node1-validator                  create
+ +   ├─ svmkit:validator:Agave  bootstrap-node-validator         create
+ +   └─ svmkit:validator:Agave  node0-validator                  create
+
+Diagnostics:
+  pulumi:pulumi:Stack (aws-network-spe-py-dev):
+    0 errors, 0 warnings, 0 informations
+```
+
+3. Log into the bootstrap node and verify the network is up and talking.
+
+```
+% pulumi stack select dev
+% ./ssh-to-host 0
+Warning: Permanently added '54.200.238.38' (ED25519) to the list of known hosts.
+Linux ip-172-31-22-205 6.1.0-26-cloud-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.112-1 (2024-09-30) x86_64
+
+The programs included with the Debian GNU/Linux system are free software;
+the exact distribution terms for each program are described in the
+individual files in /usr/share/doc/*/copyright.
+
+Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+permitted by applicable law.
+admin@ip-172-31-22-205:~$ solana config set --url http://localhost:8899
+Config File: /home/admin/.config/solana/cli/config.yml
+RPC URL: http://localhost:8899
+WebSocket URL: ws://localhost:8900/ (computed)
+Keypair Path: /home/admin/.config/solana/id.json
+Commitment: confirmed
+admin@ip-172-31-22-205:~$ solana gossip
+IP Address      | Identity                                     | Gossip | TPU   | RPC Address           | Version | Feature Set
+----------------+----------------------------------------------+--------+-------+-----------------------+---------+----------------
+172.31.22.205   | 6SZhdqo62myLUE4KXWbgzrcGWEcCFhKPVQ2UoM1T6LzR | 8001   | 8004  | 172.31.22.205:8899    | 1.18.24 | 3241752014
+172.31.21.22    | FtwBFAtBgpzfvNwP3ErjsuoejavX7pVBkoiymz5P4ksy | 8001   | 8004  | 172.31.21.22:8899     | 1.18.24 | 3241752014
+172.31.24.216   | BoKjqpFQvvyDtuRC9bXJnCRLt5rWpGQM9fS3SWUSTzCU | 8001   | none  | none                  | 1.18.24 | 3241752014
+Nodes: 3
+```
+
+4. (Optional) Tear down the example
+
+```
+% pulumi down
+```

--- a/aws-network-spe-py/__main__.py
+++ b/aws-network-spe-py/__main__.py
@@ -1,0 +1,62 @@
+import pulumi
+import pulumi_aws as aws
+import pulumi_tls as tls
+import pulumi_svmkit as svmkit
+
+from spe import Node, Genesis
+
+total_nodes = 3
+
+bootstrap_node = Node("bootstrap-node")
+genesis = Genesis(bootstrap_node)
+
+gossip_port = 8001
+
+base_flags = svmkit.agave.FlagsArgsDict({
+    "only_known_rpc": False,
+    "rpc_port": 8899,
+    "dynamic_port_range": "8002-8020",
+    "private_rpc": False,
+    "gossip_port": gossip_port,
+    "rpc_bind_address": "0.0.0.0",
+    "wal_recovery_mode": "skip_any_corrupted_record",
+    "limit_ledger_size": 50000000,
+    "block_production_method": "central-scheduler",
+    "full_snapshot_interval_slots": 1000,
+    "no_wait_for_vote_to_start_leader": True,
+    "use_snapshot_archives_at_startup": "when-newest",
+    "allow_private_addr": True,
+})
+
+bootstrap_flags = base_flags.copy()
+bootstrap_flags.update({
+    "full_rpc_api": True,
+    "no_voting": False,
+    "gossip_host": bootstrap_node.instance.private_ip,
+})
+
+bootstrap_validator = bootstrap_node.configure_validator(
+    bootstrap_flags, depends_on=[genesis.genesis])
+
+nodes = [Node(f"node{n}") for n in range(total_nodes - 1)]
+all_nodes = [bootstrap_node] + nodes
+
+for node in nodes:
+    other_nodes = [x for x in all_nodes if x != node]
+    entry_point = [x.instance.private_ip.apply(
+        lambda v: f"{v}:{gossip_port}") for x in other_nodes]
+
+    flags = base_flags.copy()
+    flags.update({
+        "entry_point": entry_point,
+        "known_validator": [x.validator_key.public_key for x in other_nodes],
+        "expected_genesis_hash": genesis.genesis.genesis_hash,
+        "full_rpc_api": node == bootstrap_node,
+        "gossip_host": node.instance.private_ip,
+    })
+
+    node.configure_validator(flags, depends_on=[bootstrap_validator])
+
+pulumi.export("nodes_public_ip", [x.instance.public_ip for x in all_nodes])
+pulumi.export("nodes_private_key", [
+              x.ssh_key.private_key_openssh for x in all_nodes])

--- a/aws-network-spe-py/requirements.txt
+++ b/aws-network-spe-py/requirements.txt
@@ -1,0 +1,5 @@
+pulumi>=3.0.0,<4.0.0
+pulumi-aws>=6.0.2,<7.0.0
+pulumi-tls>=5.0.8
+pulumi-svmkit>=0.3.0,<1.0.0
+pyright>=1.1.0,<2.0.0

--- a/aws-network-spe-py/spe/__init__.py
+++ b/aws-network-spe-py/spe/__init__.py
@@ -1,0 +1,1 @@
+from .node import *

--- a/aws-network-spe-py/spe/network.py
+++ b/aws-network-spe-py/spe/network.py
@@ -1,0 +1,43 @@
+import pulumi_aws as aws
+
+external_sg = aws.ec2.SecurityGroup(
+    "external-access",
+    description="Allow external SSH access to all of the nodes",
+    ingress=[
+        {
+            "protocol": "tcp",
+            "from_port": 0,
+            "to_port": 22,
+            "cidr_blocks": ["0.0.0.0/0"],
+        },
+    ],
+    egress=[
+        {
+            "protocol": "-1",
+            "from_port": 0,
+            "to_port": 0,
+            "cidr_blocks": ["0.0.0.0/0"],
+        }
+    ]
+)
+
+internal_sg = aws.ec2.SecurityGroup(
+    "internal-access",
+    description="Permissive internal traffic",
+    ingress=[
+        {
+            "protocol": "-1",
+            "from_port": 0,
+            "to_port": 0,
+            "self": True
+        },
+    ],
+    egress=[
+        {
+            "protocol": "-1",
+            "from_port": 0,
+            "to_port": 0,
+            "cidr_blocks": ["0.0.0.0/0"],
+        }
+    ]
+)

--- a/aws-network-spe-py/spe/node.py
+++ b/aws-network-spe-py/spe/node.py
@@ -1,0 +1,130 @@
+from typing import Union
+
+import pulumi
+import pulumi_aws as aws
+import pulumi_tls as tls
+import pulumi_svmkit as svmkit
+
+from .network import external_sg, internal_sg
+
+ami = aws.ec2.get_ami(
+    filters=[
+        {
+            "name": "name",
+            "values": ["debian-12-*"],
+        },
+        {
+            "name": "architecture",
+            "values": ["x86_64"],
+        },
+    ],
+    owners=["136693071363"],  # Debian
+    most_recent=True,
+).id
+
+agave_version = "1.18.24-1"
+
+class Node:
+    def __init__(self, name):
+        self.name = name
+
+        def _(s):
+            return f"{self.name}-{s}"
+
+        self.ssh_key = tls.PrivateKey(_("ssh-key"), algorithm="ED25519")
+        self.key_pair = aws.ec2.KeyPair(
+            _("keypair"), public_key=self.ssh_key.public_key_openssh)
+
+        self.validator_key = svmkit.KeyPair(_("validator-key"))
+        self.vote_account_key = svmkit.KeyPair(_("vote-account-key"))
+
+        self.instance = aws.ec2.Instance(
+            _("instance"),
+            ami=ami,
+            instance_type="m5.2xlarge",
+            key_name=self.key_pair.key_name,
+            vpc_security_group_ids=[external_sg.id, internal_sg.id],
+            ebs_block_devices=[
+                {
+                    "device_name": "/dev/sdf",
+                    "volume_size": 500,
+                    "volume_type": "io2",
+                    "iops": 5000,
+                },
+                {
+                    "device_name": "/dev/sdg",
+                    "volume_size": 1024,
+                    "volume_type": "io2",
+                    "iops": 5000,
+                },
+            ],
+            user_data="""#!/bin/bash
+mkfs -t ext4 /dev/sdf
+mkfs -t ext4 /dev/sdg
+mkdir -p /home/sol/accounts
+mkdir -p /home/sol/ledger
+cat <<EOF >> /etc/fstab
+/dev/sdf	/home/sol/accounts	ext4	defaults	0	0
+/dev/sdg	/home/sol/ledger	ext4	defaults	0	0
+EOF
+systemctl daemon-reload
+mount -a
+"""
+        )
+
+        self.connection = svmkit.ssh.ConnectionArgsDict({
+            "host": self.instance.public_dns,
+            "user": "admin",
+            "private_key": self.ssh_key.private_key_openssh
+        })
+
+    def configure_validator(self, flags: Union['svmkit.agave.FlagsArgs', 'svmkit.agave.FlagsArgsDict'], depends_on=[]):
+        return svmkit.validator.Agave(
+            f"{self.name}-validator",
+            connection=self.connection,
+            version=agave_version,
+            key_pairs={
+                "identity": self.validator_key.json,
+                "vote_account": self.vote_account_key.json,
+            },
+            flags=flags,
+            opts=pulumi.ResourceOptions(
+                depends_on=([self.instance] + depends_on))
+        )
+
+
+class Genesis:
+    def __init__(self, bootstrap_node: Node):
+        self.bootstrap_node = bootstrap_node
+        self.faucet_key = svmkit.KeyPair("faucet-key")
+        self.treasury_key = svmkit.KeyPair("treasury-key")
+        self.stake_account_key = svmkit.KeyPair("stake-account-key")
+
+        self.genesis = svmkit.genesis.Solana(
+            "genesis",
+            connection=self.bootstrap_node.connection,
+            version=agave_version,
+            flags={
+                "ledger_path": "/home/sol/ledger",
+                "identity_pubkey": self.bootstrap_node.validator_key.public_key,
+                "vote_pubkey": self.bootstrap_node.vote_account_key.public_key,
+                "stake_pubkey": self.stake_account_key.public_key,
+                "faucet_pubkey": self.faucet_key.public_key
+            },
+            primordial=[
+                {
+                    "pubkey": self.bootstrap_node.validator_key.public_key,
+                    "lamports": "10000000000",  # 100 SOL
+                },
+                {
+                    "pubkey": self.treasury_key.public_key,
+                    "lamports": "100000000000000",  # 100000 SOL
+                },
+                {
+                    "pubkey": self.faucet_key.public_key,
+                    "lamports": "1000000000000",  # 1000 SOL
+                },
+            ],
+            opts=pulumi.ResourceOptions(
+                depends_on=[self.bootstrap_node.instance])
+        )

--- a/aws-network-spe-py/ssh-to-host
+++ b/aws-network-spe-py/ssh-to-host
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hostindex=$1 ; shift
+
+PRIVKEY=$(mktemp)
+
+cleanup () {
+    rm -f "$PRIVKEY"
+}
+
+trap cleanup EXIT
+
+touch $PRIVKEY
+chmod 600 $PRIVKEY
+
+pulumi stack output --show-secrets nodes_private_key | jq -r ".[$hostindex]" - > $PRIVKEY
+HOSTNAME=$(pulumi stack output nodes_public_ip | jq -r ".[$hostindex]" -)
+
+ssh -o StrictHostKeyChecking=off -o UserKnownHostsFile=/dev/null -i "$PRIVKEY" "admin@$HOSTNAME" "$@"
+


### PR DESCRIPTION
# Info
This deploys a 3-node Solana cluster inside AWS using EC2 instances.  It:
1. Creates the infrastructure.
2. Performs genesis.
3. Launches validators using the bootstrap node.

# Known Problems Being Fixed Shortly
- [x] Genesis is failing for the first time, I'm not sure why, but it's something simple because it works the second time.
- [x] Snapshots aren't being made at genesis, which needs to be fixed.  But first we need to start installing the specific ledger tools for the version of the validator we're using.
