### PR TITLE
Resolve Solana Explorer on Internet

### DIFF
--- a/aws-network-spe-py/__main__.py
+++ b/aws-network-spe-py/__main__.py
@@ -122,7 +122,8 @@ explorer = svmkit.explorer.Explorer(
     name="Demo",
     symbol="DMO",
     cluster_name="demonet",
-    rpcurl="http://localhost:8899",
+    rpcurl=bootstrap_node.instance.public_dns.apply(
+        lambda ip: f"http://{ip}:{RPC_PORT}"),
     flags={
         "hostname": "0.0.0.0",
         "port": 3000,

--- a/aws-network-spe-py/__main__.py
+++ b/aws-network-spe-py/__main__.py
@@ -119,9 +119,9 @@ explorer = svmkit.explorer.Explorer(
     "bootstrap-explorer",
     connection=bootstrap_node.connection,
     environment=sol_env,
-    name="Demo",
-    symbol="DMO",
-    cluster_name="demonet",
+    name="SVMKIT Explorer",
+    symbol="KIT",
+    cluster_name="svmkitnet",
     rpcurl=bootstrap_node.instance.public_dns.apply(
         lambda ip: f"http://{ip}:{RPC_PORT}"),
     flags={

--- a/aws-network-spe-py/__main__.py
+++ b/aws-network-spe-py/__main__.py
@@ -22,7 +22,8 @@ slack_webhook_url = watchtower_config.get("slack_webhook_url") or None
 discord_webhook_url = watchtower_config.get("discord_webhook_url") or None
 telegram_bot_token = watchtower_config.get("telegram_bot_token") or None
 telegram_chat_id = watchtower_config.get("telegram_chat_id") or None
-pagerduty_integration_key = watchtower_config.get("pagerduty_integration_key") or None
+pagerduty_integration_key = watchtower_config.get(
+    "pagerduty_integration_key") or None
 twilio_account_sid = watchtower_config.get("twilio_account_sid") or None
 twilio_auth_token = watchtower_config.get("twilio_auth_token") or None
 twilio_to_number = watchtower_config.get("twilio_to_number") or None
@@ -94,7 +95,7 @@ bootstrap_flags.update({
     "no_voting": False,
     "gossip_host": bootstrap_node.instance.private_ip,
     "extra_flags": [
-        "--enable-extended-tx-metadata-storage", # Enabled so that
+        "--enable-extended-tx-metadata-storage",  # Enabled so that
         "--enable-rpc-transaction-history",      # Solana Explorer has
                                                  # the data it needs.
     ]

--- a/aws-network-spe-py/spe/network.py
+++ b/aws-network-spe-py/spe/network.py
@@ -13,6 +13,18 @@ external_sg = aws.ec2.SecurityGroup(
             "to_port": 22,
             "cidr_blocks": ["0.0.0.0/0"],
         },
+        {
+            "protocol": "tcp",
+            "from_port": 3000,
+            "to_port": 3000,
+            "cidr_blocks": ["0.0.0.0/0"],
+        },
+        {
+            "protocol": "tcp",
+            "from_port": 8899,
+            "to_port": 8899,
+            "cidr_blocks": ["0.0.0.0/0"],
+        },
     ],
     egress=[
         {


### PR DESCRIPTION
## Changes
- RPC URL to public accessible url for the explorer
- SG updated to allow 8899 (RPC) and 3000 (Explorer)
- Brand the explorer for svmkit