### PR TITLE
Use 500GB ledger volume on SPE

### DIFF
--- a/aws-network-spe-py/spe/node.py
+++ b/aws-network-spe-py/spe/node.py
@@ -61,7 +61,7 @@ class Node:
                 },
                 {
                     "device_name": "/dev/sdg",
-                    "volume_size": 204,
+                    "volume_size": 500,
                     "volume_type": "gp3",
                     "iops": iops,
                 },


### PR DESCRIPTION
Agave validator client has minimum ledger size of 50_000_000 shreds. This requires approximately 270GB based on past growth on an idle cluster.