### PR TITLE
Xen Example Uses Latest Tachyon Validator

### DIFF
--- a/aws-validator-xen-ts/aws.ts
+++ b/aws-validator-xen-ts/aws.ts
@@ -98,5 +98,6 @@ mount -a
 `,
   tags: {
     Name: `${pulumi.getStack()}-validator`,
+    Stack: pulumi.getStack(),
   },
 });

--- a/aws-validator-xen-ts/aws.ts
+++ b/aws-validator-xen-ts/aws.ts
@@ -79,7 +79,7 @@ export const instance = new aws.ec2.Instance("instance", {
     },
     {
       deviceName: "/dev/sdg",
-      volumeSize: 200,
+      volumeSize: 500,
       volumeType: "io2",
       iops: 16000,
     },

--- a/aws-validator-xen-ts/index.ts
+++ b/aws-validator-xen-ts/index.ts
@@ -19,7 +19,7 @@ new svmkit.validator.Agave(
   "validator",
   {
     connection,
-    variant: "xen",
+    variant: "tachyon",
     environment: {
       rpcURL: "https://rpc.testnet.x1.xyz",
     },

--- a/aws-validator-xen-ts/index.ts
+++ b/aws-validator-xen-ts/index.ts
@@ -57,7 +57,7 @@ new svmkit.validator.Agave(
         "5NfpgFCwrYzcgJkda9bRJvccycLUo3dvVQsVAK2W43Um",
         "FcrZRBfVk2h634L9yvkysJdmvdAprq1NM4u263NuR6LC",
       ],
-      expectedGenesisHash:"C7ucgdDEhxLTpXHhWSZxavSVmaNTUJWwT5iTdeaviDho"
+      expectedGenesisHash: "C7ucgdDEhxLTpXHhWSZxavSVmaNTUJWwT5iTdeaviDho",
     },
   },
   {

--- a/aws-validator-xen-ts/package.json
+++ b/aws-validator-xen-ts/package.json
@@ -13,6 +13,6 @@
     "@pulumi/awsx": "^2.0.2",
     "@pulumi/pulumi": "^3.113.0",
     "@pulumi/tls": "^5.0.9",
-    "@svmkit/pulumi-svmkit": "^0.25.0"
+    "@svmkit/pulumi-svmkit": "^0.27.0"
   }
 }

--- a/aws-validator-xen-ts/yarn.lock
+++ b/aws-validator-xen-ts/yarn.lock
@@ -1485,10 +1485,10 @@
     "@smithy/types" "^3.7.1"
     tslib "^2.6.2"
 
-"@svmkit/pulumi-svmkit@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@svmkit/pulumi-svmkit/-/pulumi-svmkit-0.18.0.tgz#d6b96b3aa5458913f304220736492bc00a631570"
-  integrity sha512-n5u17xdS97Iv++69yMES5AGRmRJl/qirPrVK8GpiPr1ITvgW0JJOSzz0sNp+4GYYSQiUeJSNUUR1ZA/sFVOdeA==
+"@svmkit/pulumi-svmkit@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@svmkit/pulumi-svmkit/-/pulumi-svmkit-0.27.0.tgz#689619d06f9a076cc074935c1e8f69ede2c3a73e"
+  integrity sha512-YFGdWXFpkZkwdRpS7Tm3GoTOgLCLrbGFVlaToukL7WkI+cdYnEf5HuW7oOZI6Fq4SLn/TTLlCHtRpYz5CGeAwQ==
   dependencies:
     "@pulumi/pulumi" "^3.142.0"
 


### PR DESCRIPTION
## Changes
- Use the `svmkit-tachyon-validator` package for X1 testnet
- Adjust ledger size so ledger pruning can kick in
- Tag the stack for cost tracking and other cloud ops