### PR TITLE
Mix and match solana cluster example

### DIFF
--- a/aws-network-spe-py/README.md
+++ b/aws-network-spe-py/README.md
@@ -11,12 +11,36 @@ Genesis is performed, a snapshot is distributed, and gossip is set up on private
 
 ## Pulumi Configuration Options
 
-| Name              | Description                                                       | Default Value |
-| :---------------- | :---------------------------------------------------------------- | :------------ |
-| node:count        | The number of nodes to launch, including the bootstrap node.      | 3             |
-| node:instanceType | The AWS instance type to use for all of the nodes.                | c6i.xlarge    |
-| node:instanceArch | The AWS instance architecture type to use for the AMI lookup.     | x86_64        |
-| node:volumeIOPS   | The number of IOPS to provide to the ledger and accounts volumes. | 5000          |
+| Name              | Description                                                                                              | Default Value |
+| :---------------- | :------------------------------------------------------------------------------------------------------- | :------------ |
+| node:count        | The number of nodes to launch, including the bootstrap node.                                             | 3             |
+| node:instanceArch | The AWS instance architecture type to use for the AMI lookup.                                            | x86_64        |
+| node:volumeIOPS   | The number of IOPS to provide to the ledger and accounts volumes.                                        | 5000          |
+| node:layout       | Define validator topology with kind, version, and instance type. Defaults to Agave 2.1.13-1, c6i.xlarge. | []            |
+
+### Node Layout
+
+```
+# Pulumi.{stack}.yaml
+config:
+  node:layout:
+    - kind: agave
+      version: 2.0.22-1
+    - kind: agave
+      version: 2.1.13-1
+      instance_type: c6i.2xlarge
+    - kind: firedancer
+    - kind: firedancer
+```
+
+When `node:layout` is set `node:count` is ignored.
+
+The version and instance type can be specified in the layout, but will default to these values if not provided.
+
+| Kind       | Version       | Instance Type |
+| :--------- | :------------ | :------------ |
+| agave      | 2.1.13-1      | c6i.xlarge    |
+| firedancer | 0.305.20111-2 | r7a.8xlarge   |
 
 ## Running the Example
 
@@ -132,26 +156,29 @@ This script mints a token and allocates a portion of the supply to a recipient. 
 
 In the example, the deployed validators and explorer are running remotely, so you’ll need to forward the relevant ports to your local machine if you wish to interact with the RPC API or view the Explorer in your browser. The Solana JSON RPC API typically listens on port 8899 and the Explorer on port 3000.
 
-
 Forward the ports to your local machine:
 
 ```
 ./ssh-to-host 0 -L 8899:localhost:8899 -L 3000:localhost:3000
 ```
+
 Test the RPC API by running the following command:
+
 ```
 curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id": 1,"method": "getHealth"}'
 ```
+
 Additionally you can set your local Solana config to the same port to interact with the cluster:
+
 ```
 solana set --url http://localhost:8899
 
 solana block
 ```
+
 View the explorer for the SPE in your browser at `http://localhost:3000` . Note that the explorer
 frontend requires access to the node as well, so you need to make sure you've forwarded the
 validator's RPC port to your local machine as well.
-
 
 7. (Optional) Tear down the example
 

--- a/aws-network-spe-py/spe/__init__.py
+++ b/aws-network-spe-py/spe/__init__.py
@@ -1,1 +1,9 @@
+from .layout import *
 from .node import *
+from .agave import *
+from .firedancer import *
+from .validator import *
+
+GENESIS_VERSION = "2.1.13-1"
+
+FAUCET_PORT = 9900

--- a/aws-network-spe-py/spe/agave.py
+++ b/aws-network-spe-py/spe/agave.py
@@ -1,0 +1,33 @@
+from typing import Union
+from spe.node import Node
+import pulumi
+import pulumi_svmkit as svmkit
+
+
+class Agave(pulumi.ComponentResource):
+    def __init__(self, name: str, node: Node, version: str | None, flags: svmkit.agave.FlagsArgsDict, environment: Union['svmkit.solana.EnvironmentArgs', 'svmkit.solana.EnvironmentArgsDict'], startup_policy: Union['svmkit.agave.StartupPolicyArgs', 'svmkit.agave.StartupPolicyArgsDict'],  opts: pulumi.ResourceOptions | None = None) -> None:
+        super().__init__('svmkit-examples:spe:Agave', name, None, opts)
+
+        svmkit.validator.Agave(
+            name + "-agave-validator",
+            environment=environment,
+            connection=node.connection,
+            version=version,
+            startup_policy=startup_policy,
+            shutdown_policy={
+                "force": True,
+            },
+            key_pairs={
+                "identity": node.validator_key.json,
+                "vote_account": node.vote_account_key.json,
+            },
+            flags=flags,
+            timeout_config={
+                "rpc_service_timeout": 360,
+            },
+            info={
+                "name": name,
+                "details": "An AWS network-based SPE validator node.",
+            },
+            opts=pulumi.ResourceOptions(parent=self)
+        )

--- a/aws-network-spe-py/spe/firedancer.py
+++ b/aws-network-spe-py/spe/firedancer.py
@@ -1,0 +1,23 @@
+
+from typing import Union
+from spe.node import Node
+import pulumi
+import pulumi_svmkit as svmkit
+
+
+class Firedancer(pulumi.ComponentResource):
+    def __init__(self, name: str, node: Node, version: str | None, config: svmkit.firedancer.ConfigArgsDict, environment: Union[svmkit.solana.EnvironmentArgs, svmkit.solana.EnvironmentArgsDict], opts: pulumi.ResourceOptions | None = None) -> None:
+        super().__init__('svmkit-examples:spe:Firedancer', name, None, opts)
+
+        svmkit.validator.Firedancer(
+            name + "-firedancer-validator",
+            environment=environment,
+            connection=node.connection,
+            version=version,
+            key_pairs={
+                "identity": node.validator_key.json,
+                "vote_account": node.vote_account_key.json,
+            },
+            config=config,
+            opts=pulumi.ResourceOptions(parent=self)
+        )

--- a/aws-network-spe-py/spe/layout.py
+++ b/aws-network-spe-py/spe/layout.py
@@ -1,0 +1,38 @@
+from typing import Literal, Optional
+
+# Default version for Firedancer validator
+FIREDANCER_VERSION = "0.305.20111-2"
+
+# Default instance type for Firedancer validator
+FIREDANCER_INSTANCE_TYPE = "r7a.8xlarge"
+
+# Default version for Agave validator
+AGAVE_VERSION = "2.1.13-1"
+
+# Default instance type for Agave validator
+AGAVE_INSTANCE_TYPE = "c6i.xlarge"
+
+ValidatorKind = Literal["agave", "firedancer"]
+
+
+class ValidatorLayout:
+    def __init__(self, kind: ValidatorKind, version: str, instance_type: str):
+        self.kind = kind
+        self.version = version
+        self.instance_type = instance_type
+
+
+class AgaveLayout(ValidatorLayout):
+    def __init__(self, version: Optional[str], instance_type: Optional[str]):
+        version = version if version is not None else AGAVE_VERSION
+        instance_type = instance_type if instance_type is not None else AGAVE_INSTANCE_TYPE
+
+        super().__init__("agave", version, instance_type)
+
+
+class FiredancerLayout(ValidatorLayout):
+    def __init__(self, version: Optional[str], instance_type: Optional[str]):
+        version = version if version is not None else FIREDANCER_VERSION
+        instance_type = instance_type if instance_type is not None else FIREDANCER_INSTANCE_TYPE
+
+        super().__init__("firedancer", version, instance_type)

--- a/aws-network-spe-py/spe/validator.py
+++ b/aws-network-spe-py/spe/validator.py
@@ -1,0 +1,98 @@
+from typing import Optional, Sequence
+from pulumi import Input, ComponentResource, ResourceOptions
+import pulumi_svmkit as svmkit
+
+from .node import Node
+from .layout import ValidatorLayout
+from .agave import Agave
+from .firedancer import Firedancer
+
+GOSSIP_PORT = 8001
+RPC_PORT = 8899
+
+
+class Validator(ComponentResource):
+    def __init__(self, name: str, node: Node, layout: ValidatorLayout, entry_point: Input[Sequence[Input[str]]], expected_genesis_hash: Input[str], known_validators: Input[Sequence[Input[str]]], rpc_faucet_address: Input[str],  environment: svmkit.solana.EnvironmentArgs | svmkit.solana.EnvironmentArgsDict, full_rpc_api: bool = False, no_voting: bool = False, enable_extended_tx_metadata_storage: bool = False, enable_rpc_transaction_history: bool = False, wait_for_rpc_health: bool = False, opts: Optional[ResourceOptions] = None):
+        super().__init__('svmkit-example:spe:Validator', name, None, opts)
+
+        if layout.kind == "agave":
+            self.validator = Agave(
+                node.name,
+                node=node,
+                version=layout.version,
+                flags=svmkit.agave.FlagsArgsDict({
+                    "allow_private_addr": True,
+                    "block_production_method": "central-scheduler",
+                    "dynamic_port_range": "8002-8020",
+                    "entry_point": entry_point,
+                    "expected_genesis_hash": expected_genesis_hash,
+                    "full_rpc_api": full_rpc_api,
+                    "full_snapshot_interval_slots": 1000,
+                    "gossip_host": node.instance.private_ip,
+                    "gossip_port": GOSSIP_PORT,
+                    "known_validator": known_validators,
+                    "limit_ledger_size": 50000000,
+                    "no_voting": no_voting,
+                    "no_wait_for_vote_to_start_leader": True,
+                    "only_known_rpc": False,
+                    "private_rpc": False,
+                    "rpc_bind_address": "0.0.0.0",
+                    "rpc_faucet_address": rpc_faucet_address,
+                    "rpc_port": RPC_PORT,
+                    "use_snapshot_archives_at_startup": "when-newest",
+                    "wal_recovery_mode": "skip_any_corrupted_record",
+                    "enable_extended_tx_metadata_storage": enable_extended_tx_metadata_storage,
+                    "enable_rpc_transaction_history": enable_rpc_transaction_history
+                }),
+                environment=environment,
+                startup_policy=svmkit.agave.StartupPolicyArgsDict({
+                    "wait_for_rpc_health": wait_for_rpc_health
+                }),
+                opts=ResourceOptions(parent=self)
+            )
+        elif layout.kind == "firedancer":
+            self.validator = Firedancer(
+                node.name,
+                node=node,
+                version=layout.version,
+                config=svmkit.firedancer.ConfigArgsDict({
+                    "user": "sol",
+                    "gossip": svmkit.firedancer.ConfigGossipArgsDict({
+                        "host": node.instance.private_ip,
+                        "entrypoints": entry_point,
+                    }),
+                    "layout": svmkit.firedancer.ConfigLayoutArgsDict({
+                        "affinity": "auto",
+                        "agave_affinity": "auto",
+                    }),
+                    "consensus": svmkit.firedancer.ConfigConsensusArgsDict({
+                        "known_validators": known_validators,
+                        "expected_genesis_hash": expected_genesis_hash,
+                        "identity_path": "/home/sol/validator-keypair.json",
+                        "vote_account_path": "/home/sol/vote-account-keypair.json",
+                        "wait_for_vote_to_start_leader": False,
+                    }),
+                    "ledger": svmkit.firedancer.ConfigLedgerArgsDict({
+                        "path": "/home/sol/ledger",
+                        "accounts_path": "/home/sol/accounts",
+                    }),
+                    "rpc": svmkit.firedancer.ConfigRPCArgsDict({
+                        "port": RPC_PORT,
+                    }),
+                    "extra_config": [
+                        """
+[development]
+  [development.gossip]
+     allow_private_address = true
+"""
+                    ]
+                }),
+                environment=environment,
+                opts=ResourceOptions(parent=self)
+            )
+        else:
+            raise ValueError("Unknown validator kind")
+
+        self.register_outputs({
+            "validator": self.validator,
+        })


### PR DESCRIPTION
## Changes
- Update SPE example to mix & match agave and firedancer validator clients using `node:layout`
- Refactor agave setup to custom resource
- Refactor node to a custom resource
- Represent Firedancer as custom resource
- Have validator abstraction component to configure based on layout
- Use node layout if defined or fallback to node total (all agave same version)
- Very the default instance size between agave and firedancer

## Notes
- Firedancer boots but its has 100% skip rate. It does vote and progress the root slot with the cluster. 