### PR TITLE
Match SPE Slot Per Epoch with Solana Devnet

### DIFF
--- a/aws-network-spe-py/__main__.py
+++ b/aws-network-spe-py/__main__.py
@@ -48,6 +48,7 @@ genesis = svmkit.genesis.Solana(
         "faucet_pubkey": faucet_key.public_key,
         "bootstrap_validator_stake_lamports": 10000000000,  # 10 SOL
         "enable_warmup_epochs": True,
+        "slots_per_epoch": 8192,
     },
     primordial=[
         {

--- a/gcp-network-spe-ts/index.ts
+++ b/gcp-network-spe-ts/index.ts
@@ -62,6 +62,7 @@ const genesis = new svmkit.genesis.Solana(
       faucetPubkey: faucetKey.publicKey,
       bootstrapValidatorStakeLamports: 10000000000, // 10 SOL
       enableWarmupEpochs: true,
+      slotsPerEpoch: 8192,
     },
     primordial: [
       {

--- a/gcp-network-spe-ts/index.ts
+++ b/gcp-network-spe-ts/index.ts
@@ -20,8 +20,8 @@ const runnerConfig = {};
 
 // Tuner setup
 const tunerVariant =
-    tunerConfig.get<svmkit.tuner.TunerVariant>("variant") ??
-    svmkit.tuner.TunerVariant.Generic;
+  tunerConfig.get<svmkit.tuner.TunerVariant>("variant") ??
+  svmkit.tuner.TunerVariant.Generic;
 
 // Retrieve the default tuner parameters for that variant
 const genericTunerParamsOutput = svmkit.tuner.getDefaultTunerParamsOutput({
@@ -151,15 +151,15 @@ nodes.forEach((node) => {
   );
 
   const tuner = new svmkit.tuner.Tuner(
-      node.name + "-tuner",
-      {
-        connection: node.connection,
-        params: tunerParams,
-      },
-      {
-        dependsOn: [node.instance],
-      }
-    );
+    node.name + "-tuner",
+    {
+      connection: node.connection,
+      params: tunerParams,
+    },
+    {
+      dependsOn: [node.instance],
+    }
+  );
 
   const flags: svmkit.types.input.agave.FlagsArgs = {
     ...baseFlags,


### PR DESCRIPTION
## Changes
- The default in svmkit is 150 slots which can lead to startup errors when creating stake accounts. Use devnet setting which is ~55min per epoch.

https://github.com/solana-labs/solana/blob/master/sdk/program/src/clock.rs#L85