### PR TITLE
Update agave validator version

### DIFF
--- a/aws-validator-agave-ts/index.ts
+++ b/aws-validator-agave-ts/index.ts
@@ -61,7 +61,7 @@ new svmkit.validator.Agave(
   "validator",
   {
     connection,
-    version: "2.0.15-1",
+    version: "2.1.13-1",
     environment: {
       rpcURL: networkInfo.rpcURL[0],
     },


### PR DESCRIPTION
We're updating our SPE examples to use Agave version 2.x instead of the previous default 1.18.x. This change aligns our examples with the current versions running in production environments: Mainnet is now on 2.x while Testnet is specifically running version 2.1.13. This update ensures our examples reflect the latest implementation and functionality available in the Agave ecosystem.