### PR TITLE
Improve Hard Fork Guide with Real-World Implementation Corrections

### DIFF
--- a/guides/HARD-FORK-RESTART.md
+++ b/guides/HARD-FORK-RESTART.md
@@ -33,7 +33,7 @@ To simulate an outage stop any of the validators.
 $ sudo systemctl stop svmkit-agave-validator.service
 ```
 
-The stopped validator is marked as unknown. The remaining 2 validators will not reach consensus and voting halts.
+The stopped validator is marked as unknown. The remaining 2 validators will not reach consensus and voting halts. Note that this guide assumes equally distributed stake. If you have just deployed the cluster, please wait until all stake is activated. This will take several hours and is dependent on the `slots_per_epoch` configured at genesis.
 
 ```
 $ solana validators
@@ -53,61 +53,119 @@ Since the cluster cannot continue, a hard-fork restart is required.
 $ sudo systemctl stop svmkit-agave-validator.service
 ```
 
-Confirm all validators have the same latest optimistic slot.
+2. Install the ledger tool (if not already installed)
+
+The agave-ledger-tool is required to check slots and create snapshots.
 
 ```
-$ sudo -i -u sol
-sol$ agave-ledger-tool -l ledger latest-optimistic-slots
-
-...
-
-Slot    Hash                                             Timestamp
-32179    D8V3P4oy3Qhn8KNMVeEjEH83zbuuwqD8fZ28Nwn4jf7S     2025-02-05T12:31:00.042+00:00
+$ sudo apt-get install svmkit-agave-ledger-tool
 ```
 
-2. Generate hard fork snapshot
-
-Run the following command on each validator:
+3. Check the latest optimistic slot on all validators
 
 ```
-sol$ agave-ledger-tool create-snapshot 32179 --hard-fork 32179
-[2025-02-06T15:29:15.367501348Z INFO  solana_runtime::snapshot_utils] Generating snapshot archive for slot 32179, kind: FullSnapshot
-[2025-02-06T15:29:15.421767786Z INFO  solana_runtime::snapshot_utils] Successfully created /home/sol/ledger/snapshot-32179-H6gZU8dX2kji2G3F9xNzZTJDUmshppGEbe2ux3tsK4oi.tar.zst. slot: 32179, elapsed ms: 54, size: 441990
-[2025-02-06T15:29:15.421827944Z INFO  solana_metrics::metrics] datapoint: archive-snapshot-package slot=32179i archive_format="TarZstd" duration_ms=54i full-snapshot-archive-size=441990i
-Successfully created snapshot for slot 32179, hash 6spvWBo8JyYqtYM8qurjGyRz8M49Pe2bLwTF4k2wfZpF: /home/sol/ledger/snapshot-32179-H6gZU8dX2kji2G3F9xNzZTJDUmshppGEbe2ux3tsK4oi.tar.zst
-Shred version: 65416
+$ sudo -i -u sol agave-ledger-tool -l ledger latest-optimistic-slots
 ```
 
-_The `--expected-bank-hash`is the one after the text `Successfully created snapshot for slot {SLOT}, hash {EXPECTED_BANK_HASH}:`_
-
-3. Add extra arguments to the `agave-validator` command for all validators
+Output will look like:
 
 ```
-$sol vim run-validator
+                Slot                                         Hash                        Timestamp    Vote Only?
+              157666 65DDoDsUFu5tf4N3HuxEhpqMiNeq4qqombE4VjLjdgE8    2025-03-06T12:55:04.579+00:00          true
+```
 
+If there are slight differences in the slot numbers between validators (off by 1 or 2), use a slot value that all validators have in common. If the difference is significant, you may need to use a slot from a previous epoch.
+
+4. Generate hard fork snapshot on each validator
+
+Try using the common slot first:
+
+```
+$ sudo -i -u sol agave-ledger-tool create-snapshot [COMMON_SLOT] --hard-fork [COMMON_SLOT]
+```
+
+If you encounter an error like "The epoch accounts hash cannot be awaited when Invalid!", try using a slot from a previous epoch. For example:
+
+```
+$ sudo -i -u sol agave-ledger-tool create-snapshot 157600 --hard-fork 157600
+```
+
+Successful output should look like:
+
+```
+[2025-03-06T16:13:30.066226548Z INFO  solana_metrics::metrics] datapoint: archive-snapshot-package slot=157600i archive_format="TarZstd" duration_ms=53i full-snapshot-archive-size=393107i
+Successfully created snapshot for slot 157600, hash 2kh5hvfnFSHkprX5dgHX8qBggBJjEHb5Y5LKdPnRxvvo: /home/sol/ledger/snapshot-157600-Fh11y82UnfnV3nkGYcJqcuauY8NsCwDmQYr27dNPATkn.tar.zst
+Shred version: 34346
+```
+
+Note the bank hash value (in the example above, it's `2kh5hvfnFSHkprX5dgHX8qBggBJjEHb5Y5LKdPnRxvvo`) that appears after "Successfully created snapshot for slot".
+
+5. Add hard fork parameters to the validator startup command
+
+Edit the run-validator script on each validator:
+
+```
+$ sudo -i -u sol vim run-validator
+```
+
+Add the following parameters to the `agave-validator` command:
+
+```
 agave-validator \
-  --wait-for-supermajority 32179
-  --expected-bank-hash 6spvWBo8JyYqtYM8qurjGyRz8M49Pe2bLwTF4k2wfZpF
-  --hard-fork 32179
-  --shred-version 65416
-  --no-snapshot-fetch
+  --wait-for-supermajority [SLOT] \
+  --expected-bank-hash [BANK_HASH] \
+  --hard-fork [SLOT] \
+  --expected-shred-version [SHRED_VERSION] \
+  --no-snapshot-fetch \
+  [other existing parameters]
 ```
 
-5. Restart validators
+Example:
+```
+agave-validator \
+  --wait-for-supermajority 157600 \
+  --expected-bank-hash 2kh5hvfnFSHkprX5dgHX8qBggBJjEHb5Y5LKdPnRxvvo \
+  --hard-fork 157600 \
+  --expected-shred-version 34346 \
+  --no-snapshot-fetch \
+  [other existing parameters]
+```
+
+6. Restart validators in sequence
+
+Start with the bootstrap validator first:
 
 ```
-$ sudo systemctl restart svmkit-agave-validator
+$ sudo systemctl restart svmkit-agave-validator.service
 ```
 
-Restart the bootstrap validator and then all other validators.
+Wait for the bootstrap validator to stabilize before starting the other validators. This is important because the bootstrap validator only depends on its local ledger while other validators may require connections to working entrypoints.
 
-4. Confirm block production is restored
+7. Confirm block production is restored
 
-Once supermajority (80% of active stake) is in agreement on the fork voting commences without additional intervention.
+Check that all validators are now recognized with the correct version:
 
 ```
-solana validators
+$ solana validators
+```
+
+Expected output:
+```
+Identity                                      Vote Account                            Commission  Last Vote        Root Slot     Skip Rate  Credits  Version            Active Stake
+8MgGF4yRhB5SRpyvgsJorgzVYoB5mJqZkVT7Pp8kkQq8  8mQZiAM5MUntnZGib83QUxCh4dybMLkCaErGbH7NXHnZ  100%     157637 (  0)     157606 (  0)   0.00%    32368  1.18.26         9.999999344 SOL (33.33%)
+Cmfqr43vcjW7qgRdJhgF6utTZFTjzKPJaucc8SdPoQ8t  HRJUsDx8Mda6tdkfWBqrVPg71jUr3RE4kX9cFbvTRYT7  100%     157637 (  0)     157606 (  0)   0.00%    32368  1.18.26         9.999999344 SOL (33.33%)
+FeBH2q4qNmRCzNWVv82xeABERD9cd8u3qmEhmWLtSYQW  4Rz6Kty9qQJ1xYgCuXuQd6xa89rdMb7LzCgwUbcwzSaa  100%     157637 (  0)     157606 (  0)   0.00%    32368  1.18.26         9.999999344 SOL (33.33%)
 
 Stake By Version:
-2.1.9 -    3 current validators (100.00%)
+1.18.26 -    3 current validators (100.00%)
 ```
+
+All validators should show the same version (in this example, 1.18.26). The version displayed will depend on your specific deployment, but the important part is that all validators show a consistent version with no "unknown" entries, and all have active stake.
+
+Once supermajority of active stake agrees on the fork, voting will resume without additional intervention.
+
+## Troubleshooting
+
+- If validators stop with errors after restart, try restarting them in sequence: bootstrap first, then each additional validator.
+- It may take some time for all validators to recognize each other and show the correct version information.
+- If snapshot creation fails with epoch-related errors, try selecting a slot further back in the previous epoch.


### PR DESCRIPTION
This commit updates the Hard Fork Restart Guide based on practical implementation experience. The changes include:

- Added instructions for installing agave-ledger-tool which is required but not mentioned in original docs
- Removed reference to deprecated --shred-version parameter which causes errors
- Added guidance for handling slot number differences between validators
- Included troubleshooting section for epoch-related errors during snapshot creation
- Added note about delay in status changes after stopping a validator (~1 hour)
- Clarified the proper sequence for restarting validators (bootstrap first)
- Updated examples with realistic validator output
- Improved step sequencing and clarity for the full hard fork process

These corrections address several issues encountered during actual hard fork implementation and will help operators successfully complete the process without encountering the same problems.