### PR TITLE
Add missing validator public key export

### DIFF
--- a/guides/OPERATING-VALIDATOR.md
+++ b/guides/OPERATING-VALIDATOR.md
@@ -25,6 +25,7 @@ const stakeAccountKey = new svmkit.KeyPair("stake-account-key");
 // Export public keys for funding
 export const treasuryPublicKey = treasuryKey.publicKey;
 export const stakeAccountPublicKey = stakeAccountKey.publicKey;
+export const validatorPublicKey = validatorKey.publicKey;
 ```
 
 Deploy this initial change to generate the keypairs:


### PR DESCRIPTION
This commit adds the missing export for validatorPublicKey which is needed for:

- Providing visibility to the validator's public address
- Enabling users to check validator balance using stack outputs
- Maintaining consistency with other key exports in the guide
- Ensuring the guide's monitoring commands work without modification

The validator public key export is referenced in the monitoring section but was missing from the code examples.